### PR TITLE
Introduce a --read to anlt log so logs from file can be read and parsed

### DIFF
--- a/docs/source/cli_ref/anlt/lt/index.rst
+++ b/docs/source/cli_ref/anlt/lt/index.rst
@@ -18,6 +18,7 @@ Commands for Link Training.
     
     lt_inc
     lt_dec
+    lt_no_eq
     lt_encoding
     lt_preset
     lt_trained

--- a/docs/source/cli_ref/anlt/lt/lt_no_eq.rst
+++ b/docs/source/cli_ref/anlt/lt/lt_no_eq.rst
@@ -1,0 +1,61 @@
+lt dec
+======
+
+Description
+-----------
+
+Request the remote link training turn off equalizer on its emphasis.
+
+
+
+Synopsis
+--------
+
+.. code-block:: text
+    
+    lt no_eq <SERDES> <EMPHASIS>
+
+
+Arguments
+---------
+
+``<SERDES>`` (integer)
+
+Specifies the transceiver serdes index.
+
+
+``<EMPHASIS>`` (text)
+    
+The emphasis (coefficient) of the link partner.
+
+Allowed values:
+
+* `pre3`
+
+* `pre2`
+
+* `pre``
+
+* `main`
+
+* `post`
+
+
+Options
+-------
+
+
+
+Examples
+--------
+
+.. code-block:: text
+
+    xoa-utils[123456][port0/2] > lt no_eq 0 main
+    Port 0/0: Turning off equalizer on c(0) on Serdes 0 (COEFF_STS_UPDATED)
+
+    xoa-utils[123456][port0/2] >
+
+
+
+

--- a/docs/source/cli_ref/summary/index.rst
+++ b/docs/source/cli_ref/summary/index.rst
@@ -85,6 +85,9 @@ Summary
     * - :doc:`../anlt/lt/lt_dec`
       - Request **remote port** to decrease (-) its emphasis value by 1
       - ``lt dec 0 main``
+    * - :doc:`../anlt/lt/lt_no_eq`
+      - Request **remote port** to turn off equalizer on its emphasis
+      - ``lt dec 0 main``
     * - :doc:`../anlt/lt/lt_encoding`
       - Request **remote port** to use the specified encoding on the specified serdes
       - ``lt encoding 0 pam4``

--- a/xoa_utils/clicks/click_commands/anlt.py
+++ b/xoa_utils/clicks/click_commands/anlt.py
@@ -308,7 +308,7 @@ async def anlt_log(ctx: ac.Context, filename: str, read: bool, keep: str, serdes
             log_str = await anlt_utils.anlt_log(port_obj)
         filtered = _filter_log(log_str, keep, serdes)
         string = _beautify(filtered)
-        if filename and log_str:
+        if not read and filename and log_str:
             with open(filename, "a") as f:
                 f.write(f"{log_str}\n")
         return string

--- a/xoa_utils/clicks/click_commands/anlt.py
+++ b/xoa_utils/clicks/click_commands/anlt.py
@@ -131,6 +131,9 @@ async def do(context: ac.Context) -> str:
     "-f", "--filename", type=ac.STRING, help=h.HELP_ANLT_LOG_FILENAME, default=""
 )
 @ac.option(
+    "--read", is_flag=True, help="Read the file", default=False
+)
+@ac.option(
     "-k",
     "--keep",
     type=ac.Choice(["all", "an", "lt"]),
@@ -139,7 +142,7 @@ async def do(context: ac.Context) -> str:
 )
 @ac.option("-s", "--serdes", type=ac.STRING, help=h.HELP_ANLT_LOG_SERDES, default="")
 @ac.pass_context
-async def anlt_log(ctx: ac.Context, filename: str, keep: str, serdes: str) -> str:
+async def anlt_log(ctx: ac.Context, filename: str, read: bool, keep: str, serdes: str) -> str:
     """
     Start AN/LT logging.
     """
@@ -295,10 +298,14 @@ async def anlt_log(ctx: ac.Context, filename: str, keep: str, serdes: str) -> st
         return "\n".join(real)
 
     async def log(
-        storage: CmdContext, filename: str, keep: str, serdes: list[int]
+        storage: CmdContext, filename: str, read: bool, keep: str, serdes: list[int]
     ) -> str:
-        port_obj = storage.retrieve_port()
-        log_str = await anlt_utils.anlt_log(port_obj)
+        if read:
+            with open(filename, "r") as f:
+                log_str = f.read()
+        else:
+            port_obj = storage.retrieve_port()
+            log_str = await anlt_utils.anlt_log(port_obj)
         filtered = _filter_log(log_str, keep, serdes)
         string = _beautify(filtered)
         if filename and log_str:
@@ -307,10 +314,13 @@ async def anlt_log(ctx: ac.Context, filename: str, keep: str, serdes: str) -> st
         return string
 
     real_serdes_list = [int(i.strip()) for i in serdes.split(",")] if serdes else []
-    kw = {"filename": filename, "keep": keep, "serdes": real_serdes_list}
-    storage: CmdContext = ctx.obj
-    storage.set_loop_coro(log, kw)
-    return ""
+    if read:
+        return await log(storage=None, filename=filename, read=read, keep=keep, serdes=real_serdes_list)
+    else:
+        kw = {"filename": filename, "read": read, "keep": keep, "serdes": real_serdes_list}
+        storage: CmdContext = ctx.obj
+        storage.set_loop_coro(log, kw)
+        return ""
 
 
 # --------------------------

--- a/xoa_utils/clicks/click_commands/lt.py
+++ b/xoa_utils/clicks/click_commands/lt.py
@@ -8,6 +8,7 @@ from xoa_utils.clis import (
     format_lt_config,
     format_lt_im,
     format_lt_inc_dec,
+    format_lt_no_eq,
     format_lt_encoding,
     format_lt_preset,
     format_lt_trained,
@@ -158,6 +159,33 @@ async def lt_dec(context: ac.Context, serdes: int, emphasis: str) -> str:
         port_obj, serdes, enums.LinkTrainCoeffs[emphasis.upper()]
     )
     return format_lt_inc_dec(storage, serdes, emphasis, False, resp.name)
+
+
+# **************************
+# Type: Control
+# **************************
+# **************************
+# sub-command: lt no_eq
+# **************************
+@lt.command(cls=cb.XenaCommand, name="no_eq")
+@ac.argument("serdes", type=ac.INT)
+@ac.argument("emphasis", type=ac.Choice(["pre3", "pre2", "pre", "main", "post"]))
+@ac.pass_context
+async def lt_no_eq(context: ac.Context, serdes: int, emphasis: str) -> str:
+    """
+    Request the remote port's serdes to turn off equalizing.
+
+        <SERDES>: Specifies the transceiver serdes index.
+
+        <EMPHASIS>: The emphasis (coefficient) of the link partner. Allowed values: pre3 | pre2 | pre | main | post
+    """
+    storage: CmdContext = context.obj
+    port_obj = storage.retrieve_port()
+    storage.validate_current_serdes(serdes)
+    resp = await anlt_utils.lt_coeff_no_eq(
+        port_obj, serdes, enums.LinkTrainCoeffs[emphasis.upper()]
+    )
+    return format_lt_no_eq(storage, serdes, emphasis, resp.name)
 
 
 # **************************

--- a/xoa_utils/clis/__init__.py
+++ b/xoa_utils/clis/__init__.py
@@ -12,6 +12,7 @@ from xoa_utils.clis.cli_utils import (
     format_error,
     format_an_config,
     format_lt_inc_dec,
+    format_lt_no_eq,
     format_lt_encoding,
     format_lt_preset,
     format_lt_trained,

--- a/xoa_utils/clis/cli_utils.py
+++ b/xoa_utils/clis/cli_utils.py
@@ -232,6 +232,19 @@ def format_lt_inc_dec(
     return f"Port {storage.retrieve_port_str()}: {action} {change} by 1 on Serdes {serdes} ({response})\n"
 
 
+def format_lt_no_eq(
+    storage: CmdContext, serdes: int, emphasis: str, response: str
+) -> str:
+    change = {
+        "pre3": "c(-3)",
+        "pre2": "c(-2)",
+        "pre": "c(-1)",
+        "main": "c(0)",
+        "post": "c(1)",
+    }[emphasis]
+    return f"Port {storage.retrieve_port_str()}: Turning off equalizer on {change} on Serdes {serdes} ({response})\n"
+
+
 def format_lt_encoding(
     storage: CmdContext, serdes: int, encoding: str, response: str
 ) -> str:


### PR DESCRIPTION
This feature is needed when analyzing logfiles to get a familiar output