### PR TITLE
Fix lt encoding incorrect values passed to chassis

### DIFF
--- a/xoa_utils/__init__.py
+++ b/xoa_utils/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "2.0.2"
+__version__ = "2.0.3"
 __short_version__ = "2.0"


### PR DESCRIPTION
When doing `lt encoding pam4`, the value sent to chassis is fixed to 1 (previously it was 2).
When doing `lt encoding pam4pre`, the value sent to chassis is fixed to 2 (previously it was 3).